### PR TITLE
[enhancements] Various enhancements here:

### DIFF
--- a/src/wookey/auth/WooKeyAuth.java
+++ b/src/wookey/auth/WooKeyAuth.java
@@ -41,19 +41,19 @@ public class WooKeyAuth extends Applet implements ExtendedLength
 	private void get_key(APDU apdu, byte ins){
 		/* The user asks to get the master key and its derivative, the secure channel must be initialized */
 		if(W.schannel.is_secure_channel_initialized() == false){
-			W.schannel.send_encrypted_apdu(apdu, null, (short) 0, (short) 0, ins, (byte) 0x00);
+			W.schannel.send_encrypted_apdu(apdu, null, (short) 0, (short) 0, WooKey.SW1_WARNING, (byte) 0x00);
 			return;
 		}
 		short data_len = W.schannel.receive_encrypted_apdu(apdu, W.data);
 		if(data_len != 0){
 			/* We should not receive data in this command */
-			W.schannel.send_encrypted_apdu(apdu, null, (short) 0, (short) 0, ins, (byte) 0x01);
+			W.schannel.send_encrypted_apdu(apdu, null, (short) 0, (short) 0, WooKey.SW1_WARNING, (byte) 0x01);
 			return;
 		}
 		/* We check that we are already unlocked */
 		if((W.pet_pin.isValidated() == false) || (W.user_pin.isValidated() == false)){
 			/* We are not authenticated, ask for an authentication */
-			W.schannel.send_encrypted_apdu(apdu, null, (short) 0, (short) 0, ins, (byte) 0x02);
+			W.schannel.send_encrypted_apdu(apdu, null, (short) 0, (short) 0, WooKey.SW1_WARNING, (byte) 0x02);
 			return;
 		}
 		else{

--- a/src/wookey/common/Hmac.java
+++ b/src/wookey/common/Hmac.java
@@ -7,13 +7,13 @@ import javacard.security.*;
  * The software implementation optionally uses masking to try limiting some leaks.
  */
 public class Hmac {
-	/* !!WARNING: using native HMAC can provoke unexpected errors on
-	 * cards that do not retur an error when getting an instance, but
-	 * raise an exception when using the instance ... Turn to 'false'
-	 * to fall back to software HMAC if this happens.
-	 */
-	private static final boolean TRY_USE_NATIVE_HMAC = true;
 	/* If we have native HMAC support, use it */
+        /* !!WARNING: using native HMAC can provoke unexpected errors on
+         * cards that do not retur an error when getting an instance, but
+         * raise an exception when using the instance ... Turn to 'false'
+         * to fall back to software HMAC if this happens.
+         */
+	private static final boolean TRY_USE_NATIVE_HMAC = true;
 	private boolean use_native_hmac = false;
 	Signature hmac_instance = null;
 	HMACKey hmac_key = null;
@@ -123,9 +123,9 @@ public class Hmac {
 		}
 	}
 
-        public void hmac_init(byte[] key){
+        public void hmac_init(byte[] key, short key_offset, short key_length){
 		if(use_native_hmac == true){
-			hmac_key.setKey(key, (short) 0, (short) key.length);
+			hmac_key.setKey(key, key_offset, key_length);
 			hmac_instance.init(hmac_key, Signature.MODE_SIGN);
 	        	return;
 		}
@@ -147,10 +147,10 @@ public class Hmac {
 					}
 				}
 				
-				if(key.length > ipad.length){
+				if(key_length > ipad.length){
 					/* Key length is > block size */
 					local_md.reset();
-					local_md.update(key, (short) 0, (short) key.length);
+					local_md.update(key, key_offset, key_length);
 					/* [RB] NOTE: some javacard throw an exception when the input buffer is null even if the size is 0 ...
 					 * Hence, we use a dummy value
 					 */
@@ -185,16 +185,16 @@ public class Hmac {
 				else{
 					/* Key length is <= block size */
 					for(i = 0; i < ipad.length; i++){
-						if(i < key.length){
+						if(i < key_length){
 							if(USE_HMAC_MASKING == true){
 								byte msk = (byte)(ipad_masks[i] ^ orig_ipad_masks[i] ^ 0x36);
-								ipad[i] ^= (key[i] ^ msk);
+								ipad[i] ^= (key[(short)(key_offset + i)] ^ msk);
 								msk = (byte)(opad_masks[i] ^ orig_opad_masks[i] ^ 0x5c);
-								opad[i] ^= (key[i] ^ msk);
+								opad[i] ^= (key[(short)(key_offset + i)] ^ msk);
 							}
 							else{
-								ipad[i] = (byte)(key[i] ^ 0x36);
-								opad[i] = (byte)(key[i] ^ 0x5c);
+								ipad[i] = (byte)(key[(short)(key_offset + i)] ^ 0x36);
+								opad[i] = (byte)(key[(short)(key_offset + i)] ^ 0x5c);
 							}
 						}
 						else{

--- a/src/wookey/common/SecureChannel.java
+++ b/src/wookey/common/SecureChannel.java
@@ -262,7 +262,7 @@ public class SecureChannel {
 			ISOException.throwIt((short) 0xAAAA);
 		}
 		/* HMAC context */
-		hmac_ctx.hmac_init(HMAC_key);
+		hmac_ctx.hmac_init(HMAC_key, (short) 0, (short) HMAC_key.length);
 		/* Prepend the IV */
 		hmac_ctx.hmac_update(IV, (short) 0, (short) IV.length);
 		/* Append CLA, INS, P1, P2 */
@@ -332,7 +332,7 @@ public class SecureChannel {
 		}
 
 		/* HMAC context */
-		hmac_ctx.hmac_init(HMAC_key);
+		hmac_ctx.hmac_init(HMAC_key, (short) 0, (short) HMAC_key.length);
 		/* Prepend the IV when computing the HMAC */
 		hmac_ctx.hmac_update(IV, (short) 0, (short) IV.length);
 		/* Append SW1 and SW2 */
@@ -340,7 +340,7 @@ public class SecureChannel {
 		tmp[1] = sw2;
 		hmac_ctx.hmac_update(tmp, (short) 0, (short) 1);
 		hmac_ctx.hmac_update(tmp, (short) 1, (short) 1);
-		if(indatalen > 0){
+		if((indatalen > 0) && (indata != null)){
 			aes_ctr_ctx.aes_init(AES_key, IV, Aes.DECRYPT);
 			aes_ctr_ctx.aes(indata, indataoffset, indatalen, working_buffer, (short) 0);
 	                /* Increment the IV by as many blocks as necessary */

--- a/src/wookey/sig/WooKeySIG.java
+++ b/src/wookey/sig/WooKeySIG.java
@@ -139,7 +139,7 @@ public class WooKeySIG extends Applet implements ExtendedLength
 	private void begin_sign_session(APDU apdu, byte ins){
 	        /* The user asks for beginning a signature session, secure channel must be established */
                 if(W.schannel.is_secure_channel_initialized() == false){
-                        W.schannel.send_encrypted_apdu(apdu, null, (short) 0, (short) 0, ins, (byte) 0x00);
+                        W.schannel.send_encrypted_apdu(apdu, null, (short) 0, (short) 0, WooKey.SW1_WARNING, (byte) 0x00);
                         return;
                 }
 		/* First, we close any previous signing session ... */
@@ -150,20 +150,20 @@ public class WooKeySIG extends Applet implements ExtendedLength
                  */
                 short data_len = W.schannel.receive_encrypted_apdu(apdu, W.data);
                 if(data_len != (short)((5*4) + 4 + ECCurves.get_EC_sig_len(Keys.LibECCparams))){
-                        W.schannel.send_encrypted_apdu(apdu, null, (short) 0, (short) 0, ins, (byte) 0x01);
+                        W.schannel.send_encrypted_apdu(apdu, null, (short) 0, (short) 0, WooKey.SW1_WARNING, (byte) 0x01);
 			return;
 		}
 	        /* We check that we are already unlocked */
                 if((W.pet_pin.isValidated() == false) || (W.user_pin.isValidated() == false)){
                         /* We are not authenticated, ask for an authentication */
-                        W.schannel.send_encrypted_apdu(apdu, null, (short) 0, (short) 0, ins, (byte) 0x02);
+                        W.schannel.send_encrypted_apdu(apdu, null, (short) 0, (short) 0, WooKey.SW1_WARNING, (byte) 0x02);
                         return;
                 }
 		else{
 			/* We generate our signing session IV */
                         random.generateData(sign_session_IV, (short) 0, (short) sign_session_IV.length);
 			/* Compute the HMAC of the data using our secret key */
-			hmac_ctx.hmac_init(Keys.MasterSecretKey);
+			hmac_ctx.hmac_init(Keys.MasterSecretKey, (short) 0, (short) 32);
 			hmac_ctx.hmac_update(W.data, (short) 0, (short) (data_len - ECCurves.get_EC_sig_len(Keys.LibECCparams)));
 			hmac_ctx.hmac_update(sign_session_IV, (short) 0, (short) sign_session_IV.length);
 			hmac_ctx.hmac_update(W.data, (short) (data_len - ECCurves.get_EC_sig_len(Keys.LibECCparams)), ECCurves.get_EC_sig_len(Keys.LibECCparams));
@@ -186,7 +186,7 @@ public class WooKeySIG extends Applet implements ExtendedLength
 	private void sign_fimware_hash(APDU apdu, byte ins){
                 /* The user asks for firmware signature, secure channel must be established */
                 if(W.schannel.is_secure_channel_initialized() == false){
-                        W.schannel.send_encrypted_apdu(apdu, null, (short) 0, (short) 0, ins, (byte) 0x00);
+                        W.schannel.send_encrypted_apdu(apdu, null, (short) 0, (short) 0, WooKey.SW1_WARNING, (byte) 0x00);
                         return;
                 }
 		/* First, we close any previous signing session since signing is the first action one should perform ... */
@@ -194,13 +194,13 @@ public class WooKeySIG extends Applet implements ExtendedLength
                 short data_len = W.schannel.receive_encrypted_apdu(apdu, W.data);
                 if(data_len != 32){
                         /* We should receive data in this command, and the size should be exactly 32 bytes (size of a SHA-256 hash) */
-                        W.schannel.send_encrypted_apdu(apdu, null, (short) 0, (short) 0, ins, (byte) 0x01);
+                        W.schannel.send_encrypted_apdu(apdu, null, (short) 0, (short) 0, WooKey.SW1_WARNING, (byte) 0x01);
                         return;
                 }
                 /* We check that we are already unlocked */
                 if((W.pet_pin.isValidated() == false) || (W.user_pin.isValidated() == false)){
                         /* We are not authenticated, ask for an authentication */
-                        W.schannel.send_encrypted_apdu(apdu, null, (short) 0, (short) 0, ins, (byte) 0x02);
+                        W.schannel.send_encrypted_apdu(apdu, null, (short) 0, (short) 0, WooKey.SW1_WARNING, (byte) 0x02);
                         return;
                 }
 		else{
@@ -217,19 +217,19 @@ public class WooKeySIG extends Applet implements ExtendedLength
 		short BN_len = (short) W.schannel.ec_context.p.length;
                 /* The user asks for firmware verification, secure channel must be established */
                 if(W.schannel.is_secure_channel_initialized() == false){
-                        W.schannel.send_encrypted_apdu(apdu, null, (short) 0, (short) 0, ins, (byte) 0x00);
+                        W.schannel.send_encrypted_apdu(apdu, null, (short) 0, (short) 0, WooKey.SW1_WARNING, (byte) 0x00);
                         return;
                 }
                 short data_len = W.schannel.receive_encrypted_apdu(apdu, W.data);
                 if(data_len != (short)(32 + (2 * BN_len))){
                         /* We should receive data in this command, and the size should be exactly 32 bytes (size of a hash) plus 2 big nums */
-                        W.schannel.send_encrypted_apdu(apdu, null, (short) 0, (short) 0, ins, (byte) 0x01);
+                        W.schannel.send_encrypted_apdu(apdu, null, (short) 0, (short) 0, WooKey.SW1_WARNING, (byte) 0x01);
                         return;
                 }
                 /* We check that we are already unlocked */
                 if((W.pet_pin.isValidated() == false) || (W.user_pin.isValidated() == false)){
                         /* We are not authenticated, ask for an authentication */
-                        W.schannel.send_encrypted_apdu(apdu, null, (short) 0, (short) 0, ins, (byte) 0x02);
+                        W.schannel.send_encrypted_apdu(apdu, null, (short) 0, (short) 0, WooKey.SW1_WARNING, (byte) 0x02);
                         return;
                 }
 		else{
@@ -250,43 +250,43 @@ public class WooKeySIG extends Applet implements ExtendedLength
 	private void derive_key(APDU apdu, byte ins){
                 /* The user asks for key derivation, secure channel must be established */
                 if(W.schannel.is_secure_channel_initialized() == false){
-                        W.schannel.send_encrypted_apdu(apdu, null, (short) 0, (short) 0, ins, (byte) 0x00);
+                        W.schannel.send_encrypted_apdu(apdu, null, (short) 0, (short) 0, WooKey.SW1_WARNING, (byte) 0x00);
                         return;
                 }
                 short data_len = W.schannel.receive_encrypted_apdu(apdu, W.data);
 		/* Check if a signing session is already opened */
 		if(is_sign_session_opened() == false){
-                        W.schannel.send_encrypted_apdu(apdu, null, (short) 0, (short) 0, ins, (byte) 0x01);
+                        W.schannel.send_encrypted_apdu(apdu, null, (short) 0, (short) 0, WooKey.SW1_WARNING, (byte) 0x01);
                         return;
 		}
                 if(data_len != 2){
                         /* We should receive data in this command: 2 bytes representing the chunk number */
 			close_sign_session();
-                        W.schannel.send_encrypted_apdu(apdu, null, (short) 0, (short) 0, ins, (byte) 0x02);
+                        W.schannel.send_encrypted_apdu(apdu, null, (short) 0, (short) 0, WooKey.SW1_WARNING, (byte) 0x02);
                         return;
                 }
                 /* We check that we are already unlocked */
                 if((W.pet_pin.isValidated() == false) || (W.user_pin.isValidated() == false)){
                         /* We are not authenticated, ask for an authentication */
 			close_sign_session();
-                        W.schannel.send_encrypted_apdu(apdu, null, (short) 0, (short) 0, ins, (byte) 0x03);
+                        W.schannel.send_encrypted_apdu(apdu, null, (short) 0, (short) 0, WooKey.SW1_WARNING, (byte) 0x03);
                         return;
                 }
                 short chunk_num = (short)((W.data[0] << 8) ^ (W.data[1] & 0xff));
                 if((chunk_num < 0) || (chunk_num > MAX_NUM_CHUNKS) || (session_num_chunk[0] > MAX_NUM_CHUNKS)){
 			close_sign_session();
-                        W.schannel.send_encrypted_apdu(apdu, null, (short) 0, (short) 0, ins, (byte) 0x04);
+                        W.schannel.send_encrypted_apdu(apdu, null, (short) 0, (short) 0, WooKey.SW1_WARNING, (byte) 0x04);
                         return;
                 }
 		else{
 			if((sign_session_IV == null) || (cur_session_IV == null)){
 				close_sign_session();
-                        	W.schannel.send_encrypted_apdu(apdu, null, (short) 0, (short) 0, ins, (byte) 0x05);
+                        	W.schannel.send_encrypted_apdu(apdu, null, (short) 0, (short) 0, WooKey.SW1_WARNING, (byte) 0x05);
 				return;
 			}
 			session_num_chunk[0]++;
-			Util.arrayCopyNonAtomic(Keys.MasterSecretKey, (short) 0, W.schannel.working_buffer, (short) 0, (short) 16);
-			Util.arrayCopyNonAtomic(Keys.MasterSecretKey, (short) 16, tmp, (short) 0, (short) 16);
+			Util.arrayCopyNonAtomic(Keys.MasterSecretKey, (short) 32, W.schannel.working_buffer, (short) 0, (short) 16);
+			Util.arrayCopyNonAtomic(Keys.MasterSecretKey, (short) 48, tmp, (short) 0, (short) 16);
 			aes_cbc_ctx.aes_init(W.schannel.working_buffer, tmp, Aes.ENCRYPT);
                         /* Compute current session key */
                         if(chunk_num >= last_num_chunk[0]){
@@ -310,19 +310,19 @@ public class WooKeySIG extends Applet implements ExtendedLength
         private void get_sig_type(APDU apdu, byte ins){
                 /* The user asks for the signature length, secure channel must be established */
                 if(W.schannel.is_secure_channel_initialized() == false){
-                        W.schannel.send_encrypted_apdu(apdu, null, (short) 0, (short) 0, ins, (byte) 0x00);
+                        W.schannel.send_encrypted_apdu(apdu, null, (short) 0, (short) 0, WooKey.SW1_WARNING, (byte) 0x00);
                         return;
                 }
                 /* This instruction does not have data */
                 short data_len = W.schannel.receive_encrypted_apdu(apdu, W.data);
                 if(data_len != 0){
-                        W.schannel.send_encrypted_apdu(apdu, null, (short) 0, (short) 0, ins, (byte) 0x01);
+                        W.schannel.send_encrypted_apdu(apdu, null, (short) 0, (short) 0, WooKey.SW1_WARNING, (byte) 0x01);
                         return;
                 }
                 /* We check that we are already unlocked */
                 if((W.pet_pin.isValidated() == false) || (W.user_pin.isValidated() == false)){
                         /* We are not authenticated, ask for an authentication */
-                        W.schannel.send_encrypted_apdu(apdu, null, (short) 0, (short) 0, ins, (byte) 0x02);
+                        W.schannel.send_encrypted_apdu(apdu, null, (short) 0, (short) 0, WooKey.SW1_WARNING, (byte) 0x02);
                         return;
                 }
                 else{


### PR DESCRIPTION
	- Improve the compatibility with Javacards by sending SW1/SW2 = 0x63/XX instead of
          INS/XX: this was not very ISO7816-4 compliant. Even though some cards (such as
	  NXP JCOP) are resilient and accept such exceptions, this is not the case for
	  mny other cards.
	- Improve a bit the HMAC hmac_init function with key offset and size.
	- Add some sanity checks here and there.
	- The firmware encryption master key is now 64 bytes in order to
	  properly split the HMAC key (first 32 bytes) and the AES-128-CBC key (bytes
	  32 to 48) and IV (bytes 48 to 64).
	  WARNING: this kind of breaks binary compatibility of old 'private' folders since
	  a key has been expanded.